### PR TITLE
Fixing issues

### DIFF
--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -38,7 +38,7 @@
         self.emit("found", device.address, device.name);
       }
 
-      self.emit("finished");
+      self.emit("finished", devices);
     };
   }
 

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -32,7 +32,8 @@
 
     var self = this;
 
-    this.finish = function (devices) {
+    this.finish = function (err, devices) {
+      if (err) return self.emit("error", err)
       for (const device of devices) {
         self.emit("found", device.address, device.name);
       }


### PR DESCRIPTION
I fixed the `finish` callback signature, it wasn't aware of errors. Plus I'm emiting the found devices on the `finished` event because it's really handy.

It is not backwards compatible, as the user now MUST handle the `error` event or else the app will crash.